### PR TITLE
DBA-1074 create hourly reindexer

### DIFF
--- a/.github/workflows/batch-reindex-runner.yml
+++ b/.github/workflows/batch-reindex-runner.yml
@@ -415,6 +415,12 @@ jobs:
             # throttle until AMQ transforms drain below threshold
             wait_queue
 
+            CONTINUE="$(kubectl -n "$NS" get configmap "$STATE_CM" -o jsonpath='{.data.run}' || true)"
+            if [[ "$CONTINUE" != "true" ]]; then
+              echo "ConfigMap $STATE_CM is set to not run, exiting."
+              exit 0
+            fi
+
             # move window down
             max_id="$min_id"
           done

--- a/.github/workflows/batch-reindex-runner.yml
+++ b/.github/workflows/batch-reindex-runner.yml
@@ -364,7 +364,20 @@ jobs:
               fi
               if (( $(date +%s) - start > QUEUE_WAIT_TIMEOUT_SEC )); then
                 echo "Queue did not drop below ${QUEUE_THRESHOLD} within ${QUEUE_WAIT_TIMEOUT_SEC}s (last size=${size})." >&2
-                exit 1
+                # if the repo pods haven't already been restarted in this run then do so now
+                if [[ "${restarted:-false}" != "true" ]]; then
+                  echo "Restarting repo pods now before continuing."
+                  # Restart the repo pods and reset the timer so it waits again for the queue to drain
+                  task restart_repo ENV="${ENV}"
+                  sleep 240
+                  local start=$(date +%s)
+                  local restarted=true
+                else
+                  echo "Repo pods have already been restarted in this run so exit with failure."
+                  # send Slack notification
+                  curl --silent -X POST -H 'Content-type: application/json' --data '{"blocks":[{"type":"header","text":{"type":"plain_text","text":":white_check_mark: Repository deployment restarted in ${ENV}"}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"Repository deployment restarted in ${ENV} during batch reindexing. Please check the queues."},"accessory":{"type":"button","text":{"type":"plain_text","text":":github: View Job","emoji":true},"value":"view-job","url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}","action_id":"button-action"}}]}' ${{ secrets.SLACK_WEBHOOK_URL }}
+                  exit 1
+                fi
               fi
               sleep 30
             done

--- a/.github/workflows/batch-reindex-runner.yml
+++ b/.github/workflows/batch-reindex-runner.yml
@@ -350,7 +350,6 @@ jobs:
           parse_row() { IFS='|' read -r a b c <<<"$1"; echo "$a $b $c"; }
 
           wait_queue() {
-            echo "Waiting ${INITIAL_QUEUE_SETTLE_SEC}s for queue to start filling…"; sleep "${INITIAL_QUEUE_SETTLE_SEC}"
             local start=$(date +%s)
             while true; do
               # fetch XML via utils pod then parse locally with xmllint (matches your script flow)
@@ -412,6 +411,7 @@ jobs:
             echo "Persisting next_max_id=${min_id} to $STATE_CM"
             kubectl -n "$NS" patch configmap "$STATE_CM" --type merge -p "{\"data\":{\"next_max_id\":\"${min_id}\"}}"
 
+            echo "Waiting ${INITIAL_QUEUE_SETTLE_SEC}s for queue to start filling…"; sleep "${INITIAL_QUEUE_SETTLE_SEC}"
             # throttle until AMQ transforms drain below threshold
             wait_queue
 

--- a/.github/workflows/unindexed-content-reindexer.yml
+++ b/.github/workflows/unindexed-content-reindexer.yml
@@ -88,11 +88,11 @@ on:
           - "Yes"
           - "No"
         default: "No"
-  schedule:
+  #schedule:
     # GitHub Actions cron uses UTC.
     # E.g. runs every night at:
     #   20:00 UTC
-    - cron: "0 20 * * *"
+    #- cron: "0 20 * * *"
 
 permissions:
   contents: read
@@ -285,7 +285,7 @@ jobs:
           kubectl exec -i psql-util -- /bin/sh -lc "cat > /tmp/uuids.txt" < uuids.txt
 
           # Run the mapping using a temp table and \copy
-          # Only process docs that are less than 40MB in size as larger than that won't get processed. 
+          # Only process docs that are less than 25MB in size as larger than that won't get processed. 
           kubectl exec psql-util -- /bin/sh -c "
             export PGPASSWORD='$DB_PASS';
             psql -h '$HOST' -p '$PORT' -U '$DB_USER' -d '$DBNM' -qAt <<'EOF' > /tmp/query_output.txt
@@ -303,7 +303,7 @@ jobs:
               AND p.qname_id=(SELECT id FROM alf_qname WHERE local_name='content')
               AND n.store_id = 6
               AND n.uuid IN (SELECT uuid FROM uuids)
-              AND round(u.content_size/1024/1024,2) < 40
+              AND round(u.content_size/1024/1024,2) < 25
             ORDER BY n.id;
           EOF
           "

--- a/.github/workflows/unindexed-content-runner.yml
+++ b/.github/workflows/unindexed-content-runner.yml
@@ -1,0 +1,157 @@
+#
+# Alfresco Unindexed Content Runner
+#
+# This GitHub Actions workflow automates the process of reindexing Alfresco content created or modified
+# within a specified time window (in hours). It is run from the scheduler file.
+#
+# Workflow Overview:
+# - Accepts environment and look-back window (in hours) as inputs.
+# - Finds Alfresco documents within the specified time window.
+# - Kicks off a reindex job to reindex the nodes.
+---
+name: "Alfresco: Unindexed Content Runner"
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: "Target Environment"
+        required: true
+        type: string
+      hours:
+        description: "Look-back window in hours"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  find-and-reindex:
+    runs-on: ubuntu-latest
+    strategy:
+      # If the workflow is triggered by a scheduled event (schedule), it runs for multiple environments (e.g. dev, test, stage). Otherwise, it uses the environment specified by the user input
+      matrix:
+        environment: ${{ github.event_name == 'schedule' && fromJson('["dev", "test", "stage", "preprod", "prod"]') || fromJson(format('["{0}"]', github.event.inputs.environment)) }}
+    environment: ${{ matrix.environment }}-preapproved
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: "v1.29.13"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: "v3.15.2"
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+
+      - name: Configure kubectl context
+        run: |
+          echo "${{ secrets.KUBE_CERT }}" > ca.crt
+          kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server="https://${KUBE_CLUSTER}"
+          kubectl config set-credentials deploy-user --token="${{ secrets.KUBE_TOKEN }}"
+          kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace="${KUBE_NAMESPACE}"
+          kubectl config use-context ${KUBE_CLUSTER}
+        env:
+          KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+          KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
+
+      - name: Set vars
+        id: vars
+        shell: bash
+        run: |
+          set -euo pipefail
+          ENV="${{ inputs.environment }}"
+          NS="hmpps-delius-alfresco-${ENV}"
+          # Preprod/prod spelling guard preserved if you use it in your repo; adjust if needed.
+          if [[ "${ENV}" == "poc" ]]; then NS="hmpps-delius-alfrsco-${ENV}"; fi
+          echo "ns=$NS" >> $GITHUB_OUTPUT
+          echo "env=$ENV" >> $GITHUB_OUTPUT
+
+      # --- helpers: find utils pod and retryable kubectl
+      - name: Define helper functions
+        id: helpers
+        shell: bash
+        run: |
+          cat > helpers.sh <<'EOF'
+          set -euo pipefail
+
+          kubectl_retry() {
+            local max_retries=5 delay=10 attempt=1
+            while true; do
+              if kubectl "$@"; then return 0; fi
+              echo "kubectl failed (attempt $attempt/$max_retries): kubectl $*" >&2
+              (( attempt >= max_retries )) && return 1
+              attempt=$((attempt+1)); sleep $delay
+            done
+          }
+
+          get_utils_pod() {
+            local ns="$1"
+            local pod
+            pod=$(kubectl_retry -n "$ns" get pods -l app=utils -o name 2>/dev/null | head -n1 | cut -d/ -f2 || true)
+            if [[ -z "$pod" ]]; then
+              pod=$(kubectl_retry -n "$ns" get pods --no-headers -o custom-columns=":metadata.name" | grep -m1 -E 'utils' || true)
+            fi
+            printf "%s" "$pod"
+          }
+
+          sql_in_utils() {
+            local ns="$1" q="$2"
+            local pod; pod=$(get_utils_pod "$ns")
+            [[ -z "$pod" ]] && { echo "No utils pod in $ns" >&2; exit 1; }
+            local tmp=$(mktemp)
+            cat >"$tmp" <<'EOS'
+          #!/usr/bin/env bash
+          [[ -f /etc/profile.d/psql-utils.sh ]] && . /etc/profile.d/psql-utils.sh || true
+          psqlr --tuples-only --no-align -c "$QUERY"
+          EOS
+            kubectl -n "$ns" cp "$tmp" "$pod":/tmp/run-sql.sh >/dev/null
+            rm -f "$tmp"
+            kubectl -n "$ns" exec "$pod" -- bash -lc "chmod +x /tmp/run-sql.sh; QUERY=\"$q\" /tmp/run-sql.sh; rm -f /tmp/run-sql.sh"
+          }
+          EOF
+
+      - name: Query ID range from Database
+        id: query
+        env:
+          # If scheduled look back 2 hours, otherwise use input values
+          HOURS: ${{ inputs.hours }}
+          ENV: ${{ steps.vars.outputs.env }}
+          NS:  ${{ steps.vars.outputs.ns }}
+        run: |
+          set -euo pipefail
+          source helpers.sh
+
+          get_window() {
+            sql_in_utils "$NS" "select min(n.id) as min_id, max(n.id)+1 as max_id, count(*) as node_count
+            from alf_node n 
+            join alf_store s on s.id = n.store_id 
+            where n.audit_modified > (now() - interval '${HOURS} hour')::timestamptz::text 
+            and s.protocol = 'workspace' 
+            and s.identifier = 'SpacesStore';"
+          }
+
+          parse_row() { IFS='|' read -r a b c <<<"$1"; echo "$a $b $c"; }
+
+          row="$(get_window)" || { echo "Failed to compute batch window" >&2; exit 1; }
+
+          read from_id to_id node_count <<<"$(parse_row "$row")"
+          
+          # if no rows found, exit
+          if [[ -z "$node_count" || "$node_count" -eq 0 ]]; then
+            echo "No new rows in the last ${HOURS} hours (to_id=${to_id}). Done."
+            break
+          else
+            echo "Run batch: FROM=${from_id} TO=${to_id} (count=${node_count})"
+            task reindex_by_id ENV="${ENV}" FROM="${from_id}" TO="${to_id}"
+          fi

--- a/.github/workflows/unindexed-content-schedule.yml
+++ b/.github/workflows/unindexed-content-schedule.yml
@@ -1,0 +1,24 @@
+name: "Alfresco: Unindexed Content Reindexing Schedule"
+# This workflow triggers the reindexing of unindexed content on a schedule.
+# It runs for the "preprod" and "prod" environments only.
+on:
+  schedule:
+    # Run every hour
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  batch-reindex:
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        #environment: ["preprod", "prod"]
+        environment: ["preprod"]
+    uses: ./.github/workflows/unindexed-content-runner.yml
+    with:
+      environment: ${{matrix.environment}}
+      # Look-back window in hours
+      hours: "2"
+    secrets: inherit


### PR DESCRIPTION
Update batch reindex workflow to restart repo pods if queue is not going down quickly enough.
New workflow and scheduler to run reindex_by_id jobs on a schedule (hourly). The workflow will run a reindex job for the nodes created or modified with the last 2 hours.