### PR TITLE
Training restore point

### DIFF
--- a/.github/workflows/create-rds-snapshot.yml
+++ b/.github/workflows/create-rds-snapshot.yml
@@ -79,12 +79,16 @@ jobs:
           
           SERVICE_POD_DEPLOYMENT=$(kubectl get deployment -l app=service-pod -o jsonpath="{.items[0].metadata.name}")
           ENV=${{ inputs.which_env }}
-          # service pod in Prod ns has no label with key "app", its only got "name"
-          if [ "${ENV}" = "prod" ]; then
-            SERVICE_POD_NAME=$(kubectl get pod -l name=$SERVICE_POD_DEPLOYMENT -o jsonpath="{.items[0].metadata.name}")
-          else
-            SERVICE_POD_NAME=$(kubectl get pod -l app=$SERVICE_POD_DEPLOYMENT -o jsonpath="{.items[0].metadata.name}")
+          # Try to get pod by app label first, fallback to name label
+          SERVICE_POD_NAME=$(kubectl get pod -l app=$SERVICE_POD_DEPLOYMENT -o jsonpath="{.items[0].metadata.name}" 2>/dev/null)
+          if [ -z "$SERVICE_POD_NAME" ]; then
+            SERVICE_POD_NAME=$(kubectl get pod -l name=$SERVICE_POD_DEPLOYMENT -o jsonpath="{.items[0].metadata.name}" 2>/dev/null)
+            if [ -z "$SERVICE_POD_NAME" ]; then
+              echo "Error: Could not find service pod for deployment $SERVICE_POD_DEPLOYMENT in environment $ENV"
+              exit 1
+            fi
           fi
+
 
           RDS_INSTANCE_IDENTIFIER=$(kubectl get secrets rds-instance-output -o jsonpath='{.data.RDS_INSTANCE_IDENTIFIER}' | base64 -d)
           

--- a/.github/workflows/create-rds-snapshot.yml
+++ b/.github/workflows/create-rds-snapshot.yml
@@ -32,7 +32,7 @@ jobs:
   create-rds-snapshot:
     runs-on: ubuntu-latest
     environment:
-      name: ${{ github.event.inputs.which_env }}
+      name: ${{ github.event.inputs.which_env }}-preapproved
     steps:
       - name: Checkout current repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/create-rds-snapshot.yml
+++ b/.github/workflows/create-rds-snapshot.yml
@@ -33,6 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: ${{ github.event.inputs.which_env }}-preapproved
+    env:
+      RELEASE_NAME: alfresco-content-services
+      KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+      KUBE_CLUSTER:   ${{ secrets.KUBE_CLUSTER }}
     steps:
       - name: Checkout current repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -44,9 +48,6 @@ jobs:
           kubectl config set-credentials deploy-user --token=${{ secrets.KUBE_TOKEN }}
           kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
           kubectl config use-context ${KUBE_CLUSTER}
-        env:
-          KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-          KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
 
       - name: Generate snapshot name for ${{ inputs.which_env }} namespace
         id: snapshot_name
@@ -77,12 +78,12 @@ jobs:
           #!/bin/bash
           set -xe
           
-          SERVICE_POD_DEPLOYMENT=$(kubectl get deployment -l app=service-pod -o jsonpath="{.items[0].metadata.name}")
+          SERVICE_POD_DEPLOYMENT=$(kubectl --namespace=${KUBE_NAMESPACE} get deployment -l app=service-pod -o jsonpath="{.items[0].metadata.name}")
           ENV=${{ inputs.which_env }}
           # Try to get pod by app label first, fallback to name label
-          SERVICE_POD_NAME=$(kubectl get pod -l app=$SERVICE_POD_DEPLOYMENT -o jsonpath="{.items[0].metadata.name}" 2>/dev/null)
+          SERVICE_POD_NAME=$(kubectl --namespace=${KUBE_NAMESPACE} get pod -l app=$SERVICE_POD_DEPLOYMENT -o jsonpath="{.items[0].metadata.name}" 2>/dev/null)
           if [ -z "$SERVICE_POD_NAME" ]; then
-            SERVICE_POD_NAME=$(kubectl get pod -l name=$SERVICE_POD_DEPLOYMENT -o jsonpath="{.items[0].metadata.name}" 2>/dev/null)
+            SERVICE_POD_NAME=$(kubectl --namespace=${KUBE_NAMESPACE} get pod -l name=$SERVICE_POD_DEPLOYMENT -o jsonpath="{.items[0].metadata.name}" 2>/dev/null)
             if [ -z "$SERVICE_POD_NAME" ]; then
               echo "Error: Could not find service pod for deployment $SERVICE_POD_DEPLOYMENT in environment $ENV"
               exit 1
@@ -90,14 +91,14 @@ jobs:
           fi
 
 
-          RDS_INSTANCE_IDENTIFIER=$(kubectl get secrets rds-instance-output -o jsonpath='{.data.RDS_INSTANCE_IDENTIFIER}' | base64 -d)
+          RDS_INSTANCE_IDENTIFIER=$(kubectl --namespace=${KUBE_NAMESPACE} get secrets rds-instance-output -o jsonpath='{.data.RDS_INSTANCE_IDENTIFIER}' | base64 -d)
           
           SNAPSHOT_NAME="${{ steps.snapshot_name.outputs.snapshot_name }}"
           DRY_RUN="${{ inputs.dry_run }}"
 
           create_snapshot() {
             # Exec into the service pod and execute the script
-            kubectl exec $SERVICE_POD_NAME -- /bin/sh -c \
+            kubectl exec --namespace=${KUBE_NAMESPACE} $SERVICE_POD_NAME -- /bin/sh -c \
             "aws rds create-db-snapshot \
             --db-instance-identifier '${RDS_INSTANCE_IDENTIFIER}' \
             --db-snapshot-identifier '${SNAPSHOT_NAME}'" \
@@ -107,7 +108,7 @@ jobs:
           if [ "${DRY_RUN}" = "true" ]; then
             echo "Dry run enabled, no snapshot will be created, only Checking RDS instance..."
 
-            STATUS=$(kubectl exec $SERVICE_POD_NAME -- /bin/sh -c \
+            STATUS=$(kubectl exec --namespace=${KUBE_NAMESPACE} $SERVICE_POD_NAME -- /bin/sh -c \
               "aws rds describe-db-instances \
               --db-instance-identifier '${RDS_INSTANCE_IDENTIFIER}' \
               --query 'DBInstances[0].DBInstanceStatus' \
@@ -122,7 +123,7 @@ jobs:
             create_snapshot
 
             # wait for the snapshot to be created
-            kubectl exec $SERVICE_POD_NAME -- /bin/sh -c \
+            kubectl exec --namespace=${KUBE_NAMESPACE} $SERVICE_POD_NAME -- /bin/sh -c \
             "aws rds wait db-snapshot-completed \
             --db-snapshot-identifier '${SNAPSHOT_NAME}'" \
             > /dev/null 2>&1

--- a/.github/workflows/create-rds-snapshot.yml
+++ b/.github/workflows/create-rds-snapshot.yml
@@ -78,16 +78,29 @@ jobs:
           #!/bin/bash
           set -xe
           
-          SERVICE_POD_DEPLOYMENT=$(kubectl --namespace=${KUBE_NAMESPACE} get deployment -l app=service-pod -o jsonpath="{.items[0].metadata.name}")
+          SERVICE_POD_DEPLOYMENT=$(kubectl --namespace="${KUBE_NAMESPACE}" get deployment -l app=service-pod -o jsonpath="{.items[0].metadata.name}" 2>/dev/null || true)
+          if [ -z "${SERVICE_POD_DEPLOYMENT}" ]; then
+            echo "Error: Could not find a deployment with label app=service-pod in namespace ${KUBE_NAMESPACE}" >&2
+            kubectl --namespace="${KUBE_NAMESPACE}" get deployment -l app=service-pod || true
+            exit 1
+          fi
+
           ENV=${{ inputs.which_env }}
-          # Try to get pod by app label first, fallback to name label
-          SERVICE_POD_NAME=$(kubectl --namespace=${KUBE_NAMESPACE} get pod -l app=$SERVICE_POD_DEPLOYMENT -o jsonpath="{.items[0].metadata.name}" 2>/dev/null)
-          if [ -z "$SERVICE_POD_NAME" ]; then
-            SERVICE_POD_NAME=$(kubectl --namespace=${KUBE_NAMESPACE} get pod -l name=$SERVICE_POD_DEPLOYMENT -o jsonpath="{.items[0].metadata.name}" 2>/dev/null)
-            if [ -z "$SERVICE_POD_NAME" ]; then
-              echo "Error: Could not find service pod for deployment $SERVICE_POD_DEPLOYMENT in environment $ENV"
-              exit 1
-            fi
+          # Under `set -e`, kubectl/jsonpath lookups that find nothing can exit non-zero and abort the script.
+          # Use `|| true` so we can safely fall back to alternative selectors.
+
+          # Prefer the label you verified exists on the pod (`name=<deployment-name>`), then fall back to `app=<deployment-name>`.
+          SERVICE_POD_NAME=$(kubectl --namespace="${KUBE_NAMESPACE}" get pods -l "name=${SERVICE_POD_DEPLOYMENT}" -o jsonpath="{.items[0].metadata.name}" 2>/dev/null || true)
+          if [ -z "${SERVICE_POD_NAME}" ]; then
+            SERVICE_POD_NAME=$(kubectl --namespace="${KUBE_NAMESPACE}" get pods -l "app=${SERVICE_POD_DEPLOYMENT}" -o jsonpath="{.items[0].metadata.name}" 2>/dev/null || true)
+          fi
+          if [ -z "${SERVICE_POD_NAME}" ]; then
+            echo "Error: Could not find service pod for deployment ${SERVICE_POD_DEPLOYMENT} in environment ${ENV} (namespace ${KUBE_NAMESPACE})" >&2
+            echo "Debug: pods with label name=${SERVICE_POD_DEPLOYMENT}:" >&2
+            kubectl --namespace="${KUBE_NAMESPACE}" get pods -l "name=${SERVICE_POD_DEPLOYMENT}" || true
+            echo "Debug: pods with label app=${SERVICE_POD_DEPLOYMENT}:" >&2
+            kubectl --namespace="${KUBE_NAMESPACE}" get pods -l "app=${SERVICE_POD_DEPLOYMENT}" || true
+            exit 1
           fi
 
 

--- a/tools/scripts/amq-connect.sh
+++ b/tools/scripts/amq-connect.sh
@@ -34,10 +34,14 @@ main() {
     local_port=$2
 
     # Restrict env values to only poc, dev, test or preprod
-    if [[ "$env" != "poc" && "$env" != "dev" && "$env" != "test" && "$env" != "stage" && "$env" != "preprod" && "$env" != "prod" && "$env" != "training" ]]; then
-        log_error "Invalid namespace. Allowed values: poc, dev, test, stage, preprod, prod or training."
-        exit 1
-    fi
+    case "$env" in
+        poc|dev|test|stage|preprod|prod|training)
+            ;;
+        *)
+            log_error "Invalid namespace. Allowed values: poc, dev, test, stage, preprod, prod or training."
+            exit 1
+            ;;
+    esac
 
     namespace="hmpps-delius-alfresco-${env}"
 

--- a/tools/scripts/amq-rate.sh
+++ b/tools/scripts/amq-rate.sh
@@ -24,10 +24,15 @@ log_debug() {
     echo -e "${YELLOW}$1${RESET}"
 }
 
-if [[ "$env" != "poc" && "$env" != "dev" && "$env" != "test" && "$env" != "stage" && "$env" != "preprod" && "$env" != "prod" && "$env" != "training" ]]; then
-    log_error "Invalid namespace. Allowed values: poc, dev, test, stage, preprod, training or prod."
-    exit 1
-fi
+# Restrict env values to only poc, dev, test or preprod
+case "$env" in
+    poc|dev|test|stage|preprod|prod|training)
+        ;;
+    *)
+        log_error "Invalid namespace. Allowed values: poc, dev, test, stage, preprod, prod or training."
+        exit 1
+        ;;
+esac
 
 get_total_for() {
   local stat="$1"

--- a/tools/scripts/amq-totals.sh
+++ b/tools/scripts/amq-totals.sh
@@ -20,10 +20,15 @@ log_debug() {
 
 env=$1
 
-if [[ "$env" != "poc" && "$env" != "dev" && "$env" != "test" && "$env" != "stage" && "$env" != "preprod" && "$env" != "prod" && "$env" != "training" ]]; then
-    log_error "Invalid namespace. Allowed values: poc, dev, test, stage, preprod, training or prod."
-    exit 1
-fi
+# Restrict env values to only poc, dev, test or preprod
+case "$env" in
+    poc|dev|test|stage|preprod|prod|training)
+        ;;
+    *)
+        log_error "Invalid namespace. Allowed values: poc, dev, test, stage, preprod, prod or training."
+        exit 1
+        ;;
+esac
 
 # Queue name to check
 QUEUE_NAME=$2

--- a/tools/scripts/amq-wait-empty.sh
+++ b/tools/scripts/amq-wait-empty.sh
@@ -25,10 +25,15 @@ STOP_STAT=${3:-"size"}
 INTERVAL=${4:-30}
 WARN_LEVEL=${5:-1000}
 
-if [[ "$env" != "poc" && "$env" != "dev" && "$env" != "test" && "$env" != "stage" && "$env" != "preprod" && "$env" != "prod" && "$env" != "training" ]]; then
-    log_error "Invalid namespace. Allowed values: poc, dev, test, stage, preprod, training or prod."
-    exit 1
-fi
+# Restrict env values to only poc, dev, test or preprod
+case "$env" in
+    poc|dev|test|stage|preprod|prod|training)
+        ;;
+    *)
+        log_error "Invalid namespace. Allowed values: poc, dev, test, stage, preprod, prod or training."
+        exit 1
+        ;;
+esac
   
 get_total_for() {
   local stat="$1"

--- a/tools/scripts/batch-reindex-runner.sh
+++ b/tools/scripts/batch-reindex-runner.sh
@@ -53,6 +53,8 @@ log() {
   echo "$ts $*" >> "${LOG_DIR}/reindexing.${ENV}.log"
 }
 
+log_error() { log "ERROR: $*"; }
+
 fatal() { log "FATAL: $*"; exit 1; }
 
 have_cmd() { command -v "$1" >/dev/null 2>&1; }
@@ -365,11 +367,15 @@ batches_phase() {
 main() {
   ENV=$1
 
-  # Restrict env values to only poc, dev, test, stage, preprod, training or prod
-  if [[ "$ENV" != "poc" && "$ENV" != "dev" && "$ENV" != "test" && "$ENV" != "stage" && "$ENV" != "preprod" && "$ENV" != "training" && "$ENV" != "prod" ]]; then
-      log "Invalid namespace. Allowed values: poc, dev, stage, test, preprod, training or prod."
-      exit 1
-  fi
+  # Restrict env values to only poc, dev, test or preprod
+  case "$ENV" in
+      poc|dev|test|stage|preprod|prod|training)
+          ;;
+      *)
+          log_error "Invalid namespace. Allowed values: poc, dev, test, stage, preprod, prod or training."
+          exit 1
+          ;;
+  esac
 
   if [ "$ENV" == "poc" ]; then
       K8S_NAMESPACE="hmpps-delius-alfrsco-${ENV}"

--- a/tools/scripts/opensearch-connect.sh
+++ b/tools/scripts/opensearch-connect.sh
@@ -26,11 +26,15 @@ log_debug() {
 main() {
     env=$1
 
-    # check envs
-    if [[ "$env" != "poc" && "$env" != "dev" && "$env" != "test" && "$env" != "stage" && "$env" != "preprod" && "$env" != "prod" && "$env" != "training" ]]; then
-        log_error "Invalid namespace. Allowed values: poc, dev, test, stage, preprod, prod or training."
-        exit 1
-    fi
+    # Restrict env values to only poc, dev, test or preprod
+    case "$env" in
+        poc|dev|test|stage|preprod|prod|training)
+            ;;
+        *)
+            log_error "Invalid namespace. Allowed values: poc, dev, test, stage, preprod, prod or training."
+            exit 1
+            ;;
+    esac
 
     if [ "$env" == "poc" ]; then
         namespace="hmpps-delius-alfrsco-${env}"

--- a/tools/scripts/rds-connect.sh
+++ b/tools/scripts/rds-connect.sh
@@ -27,10 +27,14 @@ main() {
     env=$1
 
     # Restrict env values to only poc, dev, test or preprod
-    if [[ "$env" != "poc" && "$env" != "dev" && "$env" != "test" && "$env" != "stage" && "$env" != "preprod" && "$env" != "prod" && "$env" != "training" ]]; then
-        log_error "Invalid namespace. Allowed values: poc, dev, test, stage, preprod, prod or training."
-        exit 1
-    fi
+    case "$env" in
+        poc|dev|test|stage|preprod|prod|training)
+            ;;
+        *)
+            log_error "Invalid namespace. Allowed values: poc, dev, test, stage, preprod, prod or training."
+            exit 1
+            ;;
+    esac
     
     if [ "$env" == "poc" ]; then
         namespace="hmpps-delius-alfrsco-${env}"
@@ -58,7 +62,8 @@ main() {
     # generate random hex string
     RANDOM_HEX=$(openssl rand -hex 4)
     # check for existing port-forward pod and use that if found
-    existing_pod=$(kubectl get pods --namespace ${namespace} -o json | jq -r ".items[] | select(.metadata.name | startswith(\"port-forward-pod-\")) | .metadata.name" | head -n1)
+    #existing_pod=$(kubectl get pods --namespace ${namespace} -o json | jq -r ".items[] | select(.metadata.name | startswith(\"port-forward-pod-\")) | .metadata.name" | head -n1)
+    existing_pod=    
     if [ -n "$existing_pod" ]; then
         log_info "Found existing port-forwarding pod: $existing_pod"
         POD_NAME=$existing_pod

--- a/tools/scripts/stream-alfresco-logs-per-pod.sh
+++ b/tools/scripts/stream-alfresco-logs-per-pod.sh
@@ -9,10 +9,10 @@
 #   The script supports environments: poc, dev, test, stage, preprod, and prod.
 #
 # Usage:
-#   ./stream-alfresco-logs-per-pod.sh <poc|dev|test|stage|preprod|prod>
+#   ./stream-alfresco-logs-per-pod.sh <poc|dev|test|stage|preprod|training|prod>
 #
 # Arguments:
-#   <environment>   The target environment/namespace (poc, dev, test, stage, preprod, or prod).
+#   <environment>   The target environment/namespace (poc, dev, test, stage, preprod, training, or prod).
 #
 # Features:
 #   - Validates the provided environment argument.
@@ -27,17 +27,25 @@
 # -----------------------------------------------------------------------------
 
 if [ -z "${1:-}" ]; then
-  echo "❌ No environment specified. Usage: $0 <poc|dev|test|stage|preprod|prod>"
+  echo "❌ No environment specified. Usage: $0 <poc|dev|test|stage|preprod|training|prod>"
   exit 1
 fi
 
+log_error() {
+    echo -e "${RED}$1${RESET}"
+}
+
 env=$1
 
-# Restrict env values to only poc, dev, test, stage, preprod or prod
-if [[ "$env" != "poc" && "$env" != "dev" && "$env" != "test" && "$env" != "stage" && "$env" != "preprod" && "$env" != "prod" ]]; then
-    log_error "Invalid namespace. Allowed values: poc, dev, test, stage, preprod or prod."
-    exit 1
-fi
+# Restrict env values to only poc, dev, test or preprod
+case "$env" in
+    poc|dev|test|stage|preprod|prod|training)
+        ;;
+    *)
+        log_error "Invalid namespace. Allowed values: poc, dev, test, stage, preprod, prod or training."
+        exit 1
+        ;;
+esac
 
 if [ "$env" == "poc" ]; then
     namespace="hmpps-delius-alfrsco-${env}"

--- a/tools/scripts/stream-alfresco-logs.sh
+++ b/tools/scripts/stream-alfresco-logs.sh
@@ -9,10 +9,10 @@
 #   (poc, dev, test, or preprod). Logs are aggregated into a timestamped file.
 #
 # Usage:
-#   ./stream-alfresco-logs.sh <poc|dev|test|stage|preprod|prod>
+#   ./stream-alfresco-logs.sh <poc|dev|test|stage|preprod|training|prod>
 #
 # Arguments:
-#   <environment>   The target environment/namespace (must be one of: poc, dev, test, stage, preprod, prod)
+#   <environment>   The target environment/namespace (must be one of: poc, dev, test, stage, preprod, training, prod)
 #
 # Features:
 #   - Validates the environment argument.
@@ -37,19 +37,27 @@ trap 'echo; echo "Stopping log streams…"; kill $(jobs -p) 2>/dev/null' EXIT
 
 
 if [ -z "${1:-}" ]; then
-  echo "❌ No environment specified. Usage: $0 <poc|dev|test|stage|preprod|prod>"
+  echo "❌ No environment specified. Usage: $0 <poc|dev|test|stage|preprod|training|prod>"
   exit 1
 fi
+
+log_error() {
+    echo -e "${RED}$1${RESET}"
+}
 
 # ——— CONFIG ——————————————————————————————————————
 # Namespace to watch
 env=$1
 
-# Restrict env values to only poc, dev, test, stage, preprod or prod
-if [[ "$env" != "poc" && "$env" != "dev" && "$env" != "test" && "$env" != "stage" && "$env" != "preprod" && "$env" != "prod" ]]; then
-    log_error "Invalid namespace. Allowed values: poc, dev, test, stage, preprod or prod."
-    exit 1
-fi
+# Restrict env values to only poc, dev, test or preprod
+case "$env" in
+    poc|dev|test|stage|preprod|prod|training)
+        ;;
+    *)
+        log_error "Invalid namespace. Allowed values: poc, dev, test, stage, preprod, prod or training."
+        exit 1
+        ;;
+esac
 
 if [ "$env" == "poc" ]; then
     namespace="hmpps-delius-alfrsco-${env}"


### PR DESCRIPTION
This pull request standardizes environment validation logic across multiple scripts and improves robustness and clarity in the RDS snapshot creation workflow. The main changes include replacing repetitive environment checks with a `case` statement, consistently allowing the `training` environment, improving error handling and namespace usage in the RDS snapshot workflow, and updating documentation to reflect these changes.

**Environment validation standardization:**

* Replaced all ad-hoc `if` checks for environment validation in scripts with a `case` statement, ensuring consistent handling of allowed environments (`poc`, `dev`, `test`, `stage`, `preprod`, `prod`, `training`). This affects scripts such as `amq-connect.sh`, `amq-rate.sh`, `amq-totals.sh`, `amq-wait-empty.sh`, `batch-reindex-runner.sh`, `opensearch-connect.sh`, `rds-connect.sh`, `stream-alfresco-logs.sh`, and `stream-alfresco-logs-per-pod.sh`. [[1]](diffhunk://#diff-e652ba5af778d39efd4871edd1fe163c8efa7dc0b468cdce390c17ec06f89a93L37-R44) [[2]](diffhunk://#diff-a99793016feaa0e2d978b7afd72070122d1dd4873b93cc05834781253ae936a0L27-R35) [[3]](diffhunk://#diff-513b2f12684870380cb144df9ebd32215fb0e34d0107594d6eda4f1b0af1a221L23-R31) [[4]](diffhunk://#diff-edc7cd85c95cab5c15a0037fbae9872e9c1e60d7e84b3b659b60123e4d85a829L28-R36) [[5]](diffhunk://#diff-38bf6989c3932770389b5f5e7819926a10fc502eb9cf1b0c005ac5a09611c25dL368-R378) [[6]](diffhunk://#diff-d290a31ebabfa659cd4bed697fb2588f4d4e01f831564488c285a7b7a8056f5dL29-R37) [[7]](diffhunk://#diff-99d1050aa6013d686f248b71e1c0868fd0f38fb4f1ba7572049c7e236570928bL30-R37) [[8]](diffhunk://#diff-48561009a005a2eb18088f8958eff5c0ee2fe0244361e6f667d812f5dd9f8a03L30-R48) [[9]](diffhunk://#diff-3667f86478fab5e4e53943027f51f038f33bf64a69c7e7c174665003bbe41fc2L40-R60)

* Updated script documentation and usage instructions to include `training` as a supported environment where appropriate. [[1]](diffhunk://#diff-48561009a005a2eb18088f8958eff5c0ee2fe0244361e6f667d812f5dd9f8a03L12-R15) [[2]](diffhunk://#diff-3667f86478fab5e4e53943027f51f038f33bf64a69c7e7c174665003bbe41fc2L12-R15)

**RDS snapshot workflow improvements:**

* Added explicit namespace (`KUBE_NAMESPACE`) and cluster (`KUBE_CLUSTER`) environment variables to the GitHub Actions workflow for RDS snapshot creation, and ensured all `kubectl` commands use the correct namespace.

* Improved error handling and logging in the RDS snapshot workflow: now checks for the existence of deployments and pods, provides detailed error/debug output if not found, and exits gracefully on failure.

* Ensured all `kubectl exec` and resource queries in the workflow explicitly specify the namespace, improving reliability and reducing risk of cross-namespace errors. [[1]](diffhunk://#diff-6002d6ebcaedf8e7cdcfe70ef87353efd63832b48950023ba658c3e4249c5a0dL80-R114) [[2]](diffhunk://#diff-6002d6ebcaedf8e7cdcfe70ef87353efd63832b48950023ba658c3e4249c5a0dL106-R124) [[3]](diffhunk://#diff-6002d6ebcaedf8e7cdcfe70ef87353efd63832b48950023ba658c3e4249c5a0dL121-R139)

**Minor script improvements:**

* Added a `log_error` helper function to several scripts for consistent error reporting. [[1]](diffhunk://#diff-38bf6989c3932770389b5f5e7819926a10fc502eb9cf1b0c005ac5a09611c25dR56-R57) [[2]](diffhunk://#diff-48561009a005a2eb18088f8958eff5c0ee2fe0244361e6f667d812f5dd9f8a03L30-R48) [[3]](diffhunk://#diff-3667f86478fab5e4e53943027f51f038f33bf64a69c7e7c174665003bbe41fc2L40-R60)

* In `rds-connect.sh`, commented out the logic for reusing an existing port-forward pod, leaving the variable empty (potentially for further revision).