### PR TITLE
Reindexing fixes

### DIFF
--- a/.github/workflows/daily-index-runner.yml
+++ b/.github/workflows/daily-index-runner.yml
@@ -167,6 +167,6 @@ jobs:
             if [ "$node_count" -gt 100000 ]; then
               sleep 900 # wait for 15 minutes before scaling down
               echo "Scaling down repository and tika deployments..."
-              task reindex_scale_down ENV={{.ENV}}
+              task reindex_scale_down ENV="${ENV}"
             fi
           fi

--- a/.github/workflows/unindexed-content-reindexer.yml
+++ b/.github/workflows/unindexed-content-reindexer.yml
@@ -3,7 +3,6 @@
 #
 # This GitHub Actions workflow automates the process of identifying and reindexing unindexed Alfresco content
 # in specified environments. It can be triggered manually (workflow_dispatch) or scheduled (cron, currently commented out).
-# If can also be used to just print the IDs of unindexed content without creating reindex jobs.
 #
 # Workflow Overview:
 # - Accepts environment and look-back window (in days) as inputs.
@@ -11,7 +10,7 @@
 # - Maps their UUIDs to alf_node IDs via a secure ephemeral pod using database credentials from Kubernetes secrets.
 # - Generates Helm values for the list of IDs to be reindexed.
 # - Cleans up any previous reindex-list configmaps.
-# - Kicks off a Helm job to reindex each identified node.
+# - Runs the reindex app on the reindexing pod.
 # - Optionally restarts the Alfresco repository deployment if the number of unindexed items exceeds a threshold.
 # - Sends a Slack notification if a restart occurs.
 #
@@ -22,7 +21,7 @@
 # 4. Map UUIDs to alf_node IDs using a temporary pod and PostgreSQL queries.
 # 5. Generate Helm values file for the IDs to be reindexed.
 # 6. Clean up any existing reindex-list configmaps.
-# 7. Deploy Helm job to perform reindexing.
+# 7. Run the reindex app on the reindexing pod.
 # 8. Output summary of found UUIDs and IDs.
 # 9. If the number of unindexed items exceeds a threshold, restart the repository deployment and notify via Slack.
 #
@@ -355,18 +354,6 @@ jobs:
             echo "no_ids=false" >> $GITHUB_OUTPUT
           fi
 
-          # There is a limit of 100 pods so check how many are running now
-          count_pods=$(kubectl get pods --no-headers 2>/dev/null | wc -l | tr -d '[:space:]')
-          if (( count_reindex + count_pods > 95 )); then
-            cat ids.txt
-            echo "Found $count_reindex alf_node ids to reindex. There are currently $count_pods pods running, which would exceed the limit of 100 pods if we started a reindex pod for each id. Please reduce the number of ids to reindex." >&2
-            if [ "${{ github.event.inputs.send_slack_notification }}" == "Yes" ]; then
-              # Send Slack notification
-              curl --silent -X POST -H 'Content-type: application/json' --data '{"blocks":[{"type":"header","text":{"type":"plain_text","text":":white_check_mark: Found too many alf_node ids ($count_reindex) to reindex in ${TASK_ENV}"}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"Found too many alf_node ids ($count_reindex) to reindex in ${TASK_ENV}."},"accessory":{"type":"button","text":{"type":"plain_text","text":":github: View Job","emoji":true},"value":"view-job","url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}","action_id":"button-action"}}]}' ${{ secrets.SLACK_WEBHOOK_URL }}
-            fi
-            exit 1
-          fi
-
       - name: Generate Helm values for reindex-list
         if: steps.mapids.outputs.no_ids == 'false'
         run: |
@@ -391,21 +378,17 @@ jobs:
             task delete_existing_reindex_configmaps_for_range ENV=${TASK_ENV} FROM=${id} TO=${next_id}
           done < ids.txt
 
-      - name: Kick off reindex (one container per ID)
+      - name: Kick off reindex
         if: github.event.inputs.skip_reindex_jobs == 'No' && steps.mapids.outputs.no_ids == 'false'
         env:
           KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+          TASK_ENV: ${{ matrix.environment }}
         run: |
           set -euo pipefail
-
-          OPEN_SEARCH_PREFIX=$(kubectl get svc --namespace ${KUBE_NAMESPACE} | grep 'opensearch-proxy-service-cloud-platform' | awk '{ print $1 }')
-          OPENSEARCH_HOST=$(echo "${OPEN_SEARCH_PREFIX}.${KUBE_NAMESPACE}.svc.cluster.local")
-          RELEASE="reindex-list-$(openssl rand -hex 4)"
-          #helm install "$RELEASE" ./jobs/reindex-list \
-          #  --set "global.elasticsearch.host=${OPENSEARCH_HOST}" \
-          #  -f ids.values.yaml \
-          #  --namespace "${KUBE_NAMESPACE}"
-          #echo "Installed Helm release: $RELEASE"
+          while IFS= read -r id; do
+            next_id=$((id + 1))
+            task reindex_by_id ENV="${TASK_ENV}" FROM="${id}" TO="${next_id}" SKIP_CM_DELETION=true
+          done < ids.txt
 
       - name: Summary
         run: |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -242,8 +242,12 @@ tasks:
   # ID FORMAT: alf-node id
   reindex_by_id:
     desc: >
-      Reindex Alfresco documents and/or metadata by ID range using Helm.
+      Reindex Alfresco documents and/or metadata by ID range.
       Requires FROM and TO environment variables to define the ID range.
+
+      This task prefers to exec into an existing reindexing pod (to avoid creating
+      additional Helm Jobs/Pods and hitting the ~100 pod quota). If no reindexing
+      pod is found, it falls back to installing the Helm Job.
 
       Automatically scales up deployments if the ID range is greater than 100,000.
 
@@ -329,8 +333,12 @@ tasks:
   # INDEX_CONTENT=false task reindex_by_date
   reindex_by_date:
     desc: >
-      Reindex Alfresco documents and/or metadata by date range using Helm.
+      Reindex Alfresco documents and/or metadata by date range.
       Requires FROM and TO environment variables to define the range.
+
+      This task prefers to exec into an existing reindexing pod (to avoid creating
+      additional Helm Jobs/Pods and hitting the ~100 pod quota). If no reindexing
+      pod is found, it falls back to installing the Helm Job.
 
       Optionally set INDEX_CONTENT to 'false' to skip content indexing and only reindex metadata.
       Defaults to 'true' (index both content and metadata).


### PR DESCRIPTION
This pull request updates the reindexing workflows and tasks to reduce the risk of exceeding Kubernetes pod quotas and to clarify documentation. The main change is a shift from launching a new Helm Job/Pod for each reindex operation to preferring execution within an existing reindexing pod, improving resource efficiency and reliability. Several documentation updates clarify these changes and the overall process.

**Reindexing process improvements:**

* The unindexed content reindexer workflow (`unindexed-content-reindexer.yml`) has been updated to run the reindex app on the reindexing pod instead of deploying a Helm job per ID, further reducing pod usage. [[1]](diffhunk://#diff-84320bdfed96f4483295fd5e57569d7b410be9c4d831a630e9b092476f0d71baL6-R13) [[2]](diffhunk://#diff-84320bdfed96f4483295fd5e57569d7b410be9c4d831a630e9b092476f0d71baL25-R24) [[3]](diffhunk://#diff-84320bdfed96f4483295fd5e57569d7b410be9c4d831a630e9b092476f0d71baL394-R391)

**Resource management changes:**

* The workflow step that checked for the Kubernetes pod limit and blocked reindexing if it would be exceeded has been removed, since the new approach minimizes pod creation. (`unindexed-content-reindexer.yml`)

**Documentation and variable handling:**

* Documentation in workflow files has been updated to reflect the new pod execution strategy and clarify the workflow steps. (`unindexed-content-reindexer.yml`) [[1]](diffhunk://#diff-84320bdfed96f4483295fd5e57569d7b410be9c4d831a630e9b092476f0d71baL6-R13) [[2]](diffhunk://#diff-84320bdfed96f4483295fd5e57569d7b410be9c4d831a630e9b092476f0d71baL25-R24)
* A minor fix was made to the environment variable syntax in the daily index runner workflow for consistency and correctness. (`daily-index-runner.yml`)